### PR TITLE
renewal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,7 @@ to be added in .env:
 
 ## Usage
 
-There are multiple ways to install Laravel Packages, but we recommend two here based on the current setup:
-
-* including private repo
-* local installation
-
-### Private Repo Installation
-
-One option is installing it from the private Git repository. For that composer.json should have something like
+Installing it from the private Git repository. For  composer.json should have something like:
 
 ```
 {
@@ -72,33 +65,11 @@ See also this [url](https://likegeeks.com/install-and-use-non-composer-laravel-p
 
 Once that is done you install it with composer. 
 
-### Local Installation
-
-Other option is local installing:
-
-* Copy the zip file over to the vendors folder 
-* unzip it and rename it as need be
-* Copy over package requirements into app composer.json (autoload class and required package) 
-
-### Local Manual Installation
-
-* Put package into your project (e.g. packages/imagewize/ssl-manager) 
-* add the following to your project's composer.json:
-```
-"autoload": {
-....
-"psr-4": {
-...
-"Imagewize\SslManager\": "packages/imagewize/ssl-manager/src/"
-}
-},
-```
-
-Don't forget about *composer dump-autoload*.
 
 ## Step 1 Install package
 
 Stonemax package will be installed automatically when you run:
+
 ```
 composer install
 ```

--- a/src/Commands/SslControllerUpdateCertificate.php
+++ b/src/Commands/SslControllerUpdateCertificate.php
@@ -14,7 +14,7 @@ class SslControllerUpdateCertificate extends Command
      *
      * @var string
      */
-    protected $signature = 'ssl-controller:update-certificate {domain} {now=false}';
+    protected $signature = 'ssl-controller:update-certificate {domain} {now=false} {renew=false}';
 
     /**
      * The console command description.
@@ -46,11 +46,17 @@ class SslControllerUpdateCertificate extends Command
      */
     public function handle(SslService $sslService)
     {
-        // https://goo.gl/JRx2aY Matt Stauffer $this->argument('argumentName')
+        /**
+         * See https://laravel.com/docs/6.x/artisan#command-structure
+         * 
+         * NB Renewing causes deletion of the current certificate 
+         * so only use `true` for 3rd parameter when need be
+         * 
+         **/
+        
         $domain = $this->argument('domain');
-        // renewing cause deletion of the current certificate
-        $renew = false;
         $now = $this->argument('now');
+        $renew = $this->argument('renew');
 
         if ($now == 'true') {
             $this->info("Certificate updating now.");


### PR DESCRIPTION
Option to choose renewal and replace certificates when need be. This so we can patch or replace certificates when issues occur. This does not (yet) solve issue with removal of certificates due to failed GET request or other. But I think this is worth testing.