### PR TITLE
Fast CGI Unix Socket Location change 

### DIFF
--- a/src/views/site.blade.php
+++ b/src/views/site.blade.php
@@ -78,6 +78,8 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php8.1-fpm.sock;
         fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
         include fastcgi_params;
     }
 }


### PR DESCRIPTION
dhparam location change since migration to ploi.io managed servers.

```
# ssl_dhparam /etc/ssl/certs/dhparam.pem;
ssl_dhparam /etc/nginx/dhparams.pem;
```

but we added new dhparam anew with 

```
sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 4096
```

but still a Unix socket location change remained for ploi.io set up Ubuntu server.  So we needed

```
fastcgi_pass unix:/run/php/php8.1-fpm.sock;
```

without `var`