### PR TITLE
Nginx reload with init.d

### DIFF
--- a/src/config/ssl-manager.php
+++ b/src/config/ssl-manager.php
@@ -49,8 +49,12 @@ return [
 
     /**
      * Command for reloading HTTP server's config.
+     * 
+     * Ubuntu servers with init.d - passwordless sudo for command 
+     * needed
      */
-    'http_config_reload' => '/usr/sbin/nginx -s reload',
+    // 'http_config_reload' => '/usr/sbin/nginx -s reload',
+    'http_config_reload' => 'sudo /etc/init.d/nginx restart',
 
     'notification_failed_email' => env('SSL_NOTIFICATION_FAILED_EMAIL'),
 ];

--- a/src/config/ssl-manager.php
+++ b/src/config/ssl-manager.php
@@ -53,7 +53,6 @@ return [
      * Ubuntu servers with init.d - passwordless sudo for command 
      * needed
      */
-    // 'http_config_reload' => '/usr/sbin/nginx -s reload',
     'http_config_reload' => 'sudo /etc/init.d/nginx restart',
 
     'notification_failed_email' => env('SSL_NOTIFICATION_FAILED_EMAIL'),


### PR DESCRIPTION
Update path to Nginx as used in current `ssl-manager.php` config file:

```
'http_config_reload' => 'sudo /etc/init.d/nginx restart',
```

Could turn this in to a default value to and add it to `.env` file. But could leave it be as Ubuntu is pretty dominant .